### PR TITLE
BI-8388 Add new environment variables

### DIFF
--- a/groups/order-notification-sender/main.tf
+++ b/groups/order-notification-sender/main.tf
@@ -77,5 +77,7 @@ module "order-notification-ecs" {
     docker_registry = var.docker_registry
     release_version = var.release_version
     java_mem_args = var.java_mem_args
+    kafka_producer_timeout = var.kafka_producer_timeout
+    maximum_retries = var.maximum_retries
   }, module.order-notification-secrets.secrets_arn_map)
 }

--- a/groups/order-notification-sender/module-ecs/task-definition.tmpl
+++ b/groups/order-notification-sender/module-ecs/task-definition.tmpl
@@ -12,7 +12,9 @@
       }
     },
     "environment": [
-      { "name": "JAVA_MEM_ARGS", "value": "${java_mem_args}" }
+      { "name": "JAVA_MEM_ARGS", "value": "${java_mem_args}" },
+      { "name": "KAFKA_PRODUCER_TIMEOUT", "value": "${kafka_producer_timeout}" },
+      { "name": "MAXIMUM_RETRIES", "value": "${maximum_retries}" }
     ],
     "healthCheck": {
       "command": ["CMD-SHELL", "curl --fail http://localhost:8081/healthcheck || exit 1"],
@@ -26,7 +28,8 @@
       { "name": "API_URL", "valueFrom": "${order-notification-secret-api-url}"},
       { "name": "CHS_API_KEY", "valueFrom": "${order-notification-secret-chs-api-key}"},
       { "name": "PAYMENTS_API_URL", "valueFrom": "${order-notification-secret-payments-api-url}"},
-      { "name": "IS_ERROR_QUEUE_CONSUMER", "valueFrom": "${order-notification-secret-error-consumer}"}
+      { "name": "IS_ERROR_QUEUE_CONSUMER", "valueFrom": "${order-notification-secret-error-consumer}"},
+      { "name": "EMAIL_SENDER_ADDRESS", "valueFrom": "${order-notification-secret-email-sender-address}"}
     ]
   }
 ]

--- a/groups/order-notification-sender/variables.tf
+++ b/groups/order-notification-sender/variables.tf
@@ -80,3 +80,15 @@ variable "java_mem_args" {
   type = string
   default = ""
 }
+
+variable "kafka_producer_timeout" {
+  description = "The amount of time after which the Kafka producer will timeout."
+  type = number
+  default = 60
+}
+
+variable "maximum_retries" {
+  description = "The number of retries permitted before the message will be sent to the error topic."
+  type = number
+  default = 5
+}


### PR DESCRIPTION
* Producer timeout variable responsible for determining length of time
after which a TimeoutException will be thrown by the Kafka producer.
* Maximum retries variable responsible for determining the number of
times the message will be republished to
order-receivied-notification-retry topic before going to
order-received-notification-error.
* Email sender address variable denotes the email sender that will be
rendered in the email.