### PR TITLE
BI-8401 Add dispatch days env var

### DIFF
--- a/groups/order-notification-sender/module-ecs/task-definition.tmpl
+++ b/groups/order-notification-sender/module-ecs/task-definition.tmpl
@@ -29,7 +29,8 @@
       { "name": "CHS_API_KEY", "valueFrom": "${order-notification-secret-chs-api-key}"},
       { "name": "PAYMENTS_API_URL", "valueFrom": "${order-notification-secret-payments-api-url}"},
       { "name": "IS_ERROR_QUEUE_CONSUMER", "valueFrom": "${order-notification-secret-error-consumer}"},
-      { "name": "EMAIL_SENDER_ADDRESS", "valueFrom": "${order-notification-secret-email-sender-address}"}
+      { "name": "EMAIL_SENDER_ADDRESS", "valueFrom": "${order-notification-secret-email-sender-address}"},
+      { "name": "DISPATCH_DAYS", "valueFrom": "${order-notification-secret-dispatch-days}"}
     ]
   }
 ]


### PR DESCRIPTION
* The DISPATCH_DAYS environment var is used to render a snippet of text
indicating the expected time required to dispatch an order.