### PR TITLE
BI-10168 - Add secret for duplicate message cache size

### DIFF
--- a/groups/order-notification-sender/module-ecs/task-definition.tmpl
+++ b/groups/order-notification-sender/module-ecs/task-definition.tmpl
@@ -32,7 +32,8 @@
       { "name": "EMAIL_SENDER_ADDRESS", "valueFrom": "${order-notification-secret-email-sender-address}"},
       { "name": "DISPATCH_DAYS", "valueFrom": "${order-notification-secret-dispatch-days}"},
       { "name": "DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED", "valueFrom": "${order-notification-secret-llp-enabled}"},
-      { "name": "DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED", "valueFrom": "${order-notification-secret-lp-enabled}"}
+      { "name": "DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED", "valueFrom": "${order-notification-secret-lp-enabled}"},
+      { "name": "DUPLICATE_MESSAGE_CACHE_SIZE", "valueFrom": "${order-notification-secret-cache-size}"},
     ]
   }
 ]


### PR DESCRIPTION
- Add a secret (DUPLICATE_MESSAGE_CACHE_SIZE) for duplicate message cache size which is responsible for filtering duplicate messages.

Relates to: [BI-10168](https://companieshouse.atlassian.net/browse/BI-10168)